### PR TITLE
Add query param support for the websocket connections

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5916,8 +5916,7 @@
     "querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
-      "dev": true
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
     "querystring-es3": {
       "version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -31,9 +31,10 @@
     "webpack-cli": "^3.3.10"
   },
   "dependencies": {
+    "@gkt/microphone": "^1.0.3",
     "core-js": "^3.2.1",
-    "uuid": "^3.3.3",
-    "@gkt/microphone": "^1.0.3"
+    "querystring": "^0.2.0",
+    "uuid": "^3.3.3"
   },
   "jest": {
     "transform": {

--- a/src/Transcriber.js
+++ b/src/Transcriber.js
@@ -10,7 +10,6 @@ class Transcriber extends EventEmitter {
     webSocket = window.WebSocket,
     audioContext = window.AudioContext || window.webkitAudioContext,
     microphone = Microphone,
-    interpreter = 'auto',
     maxFinalWait = 5000,
   } = {}) {
     super();
@@ -21,7 +20,6 @@ class Transcriber extends EventEmitter {
     this.WebSocket = webSocket;
     this.AudioContext = audioContext;
     this.Microphone = microphone;
-    this.interpreter = interpreter;
     this.maxFinalWait = maxFinalWait;
     this.state = UNINITIALIZED;
   }
@@ -54,11 +52,6 @@ class Transcriber extends EventEmitter {
       });
 
     return this._initPromise;
-  }
-
-  setInterpreter(interpreter) {
-    this.interpreter = interpreter;
-    return this;
   }
 
   start() {
@@ -150,7 +143,7 @@ class Transcriber extends EventEmitter {
 
   _openAudioSocket(sessionId) {
     return new Promise((resolve, reject) => {
-      const path = `${this.gkUrl}/audio/${sessionId}?interpreters=${this.interpreter}`;
+      const path = `${this.gkUrl}/audio/${sessionId}`;
       const socket = new this.WebSocket(this._webSocketUrl(path));
       socket.onopen = () => resolve(socket);
       socket.onerror = e => reject(e);

--- a/src/Transcriber.test.js
+++ b/src/Transcriber.test.js
@@ -81,14 +81,6 @@ describe('#init', () => {
   });
 });
 
-describe('#setInterpreter', () => {
-  it('sets the interpreter prop', () => {
-    expect(transcriber.interpreter).toBe('auto');
-    transcriber.setInterpreter('foo');
-    expect(transcriber.interpreter).toBe('foo');
-  });
-});
-
 describe('#start', () => {
   describe('when not READY', () => {
     it('throws an exception', () => {


### PR DESCRIPTION
This PR updates the `Transcript` constructor to take two new options: `audioParams` and `relayParams`. These objects will be serialized into query params on the respective urls used to open the websocket connections.

The immediate use case for this is to allow us to pass along a username from the client to audioserver without using HTTP basic auth.