### PR TITLE
Update Transcriber#start to accept audio and relay params.

### DIFF
--- a/src/Transcriber.js
+++ b/src/Transcriber.js
@@ -69,8 +69,8 @@ class Transcriber extends EventEmitter {
     this.state = INITIALIZING_RECORDING;
 
     const sessionId = uuid();
-    const socketAudioParams = Object.assign({}, this.audioParams, audioParams);
-    const socketRelayParams = Object.assign({}, this.relayParams, relayParams);
+    const socketAudioParams = {...this.audioParams, ...audioParams};
+    const socketRelayParams = {...this.relayParams, ...relayParams};
 
     return Promise.all([
       this._openAudioSocket(sessionId, socketAudioParams).then(socket => {

--- a/src/Transcriber.js
+++ b/src/Transcriber.js
@@ -12,14 +12,15 @@ class Transcriber extends EventEmitter {
     audioContext = window.AudioContext || window.webkitAudioContext,
     microphone = Microphone,
     maxFinalWait = 5000,
-    audioParams = null,
-    relayParams = null,
+    audioParams = {},
+    relayParams = {},
   } = {}) {
     super();
     this.gkUrl = gkUrl;
-    this.getUserMedia = getUserMedia || (navigator.mediaDevices && navigator.mediaDevices.getUserMedia.bind(
-      navigator.mediaDevices
-    ));
+    this.getUserMedia =
+      getUserMedia ||
+      (navigator.mediaDevices &&
+        navigator.mediaDevices.getUserMedia.bind(navigator.mediaDevices));
     this.WebSocket = webSocket;
     this.AudioContext = audioContext;
     this.Microphone = microphone;
@@ -44,7 +45,8 @@ class Transcriber extends EventEmitter {
           .getAudioTracks()[0]
           .label.replace(/^default - /i, '');
         this.microphone = new this.Microphone(this.stream, {
-          exportSampleRate: 16000, audioContext: this.AudioContext
+          exportSampleRate: 16000,
+          audioContext: this.AudioContext,
         });
         this.state = READY;
         this.emit(TRANSCRIBER_READY, this);
@@ -59,7 +61,7 @@ class Transcriber extends EventEmitter {
     return this._initPromise;
   }
 
-  start() {
+  start({audioParams = {}, relayParams = {}} = {}) {
     if (this.state !== READY) {
       throw new Error('Transcriber#start: not ready');
     }
@@ -67,14 +69,16 @@ class Transcriber extends EventEmitter {
     this.state = INITIALIZING_RECORDING;
 
     const sessionId = uuid();
+    const socketAudioParams = Object.assign({}, this.audioParams, audioParams);
+    const socketRelayParams = Object.assign({}, this.relayParams, relayParams);
 
     return Promise.all([
-      this._openAudioSocket(sessionId).then(socket => {
+      this._openAudioSocket(sessionId, socketAudioParams).then(socket => {
         this.audioSocket = socket;
         this.audioSocket.onclose = () =>
           this._handleSocketClose(this.audioSocket);
       }),
-      this._openRelaySocket(sessionId).then(socket => {
+      this._openRelaySocket(sessionId, socketRelayParams).then(socket => {
         this.relaySocket = socket;
         this.relaySocket.onclose = () =>
           this._handleSocketClose(this.relaySocket);
@@ -91,7 +95,7 @@ class Transcriber extends EventEmitter {
         this.error = error;
         this.state = ERROR;
         throw error;
-      }
+      },
     );
   }
 
@@ -139,18 +143,20 @@ class Transcriber extends EventEmitter {
 
   _requestAudioPermission() {
     if (!this.getUserMedia) {
-      return Promise.reject("no access to navigator.mediaDevices.getUserMedia, the application may need to be served over HTTPS");
+      return Promise.reject(
+        'no access to navigator.mediaDevices.getUserMedia, the application may need to be served over HTTPS',
+      );
     }
-    return this.getUserMedia({ audio: true, video: false }).then(
-      stream => stream
+    return this.getUserMedia({audio: true, video: false}).then(
+      stream => stream,
     );
   }
 
-  _openAudioSocket(sessionId) {
+  _openAudioSocket(sessionId, params) {
     return new Promise((resolve, reject) => {
       let path = `${this.gkUrl}/audio/${sessionId}`;
-      if (this.audioParams) {
-        path = `${path}?${querystring.encode(this.audioParams)}`
+      if (Object.keys(params).length) {
+        path = `${path}?${querystring.encode(params)}`;
       }
       const socket = new this.WebSocket(this._webSocketUrl(path));
       socket.onopen = () => resolve(socket);
@@ -158,11 +164,11 @@ class Transcriber extends EventEmitter {
     });
   }
 
-  _openRelaySocket(sessionId) {
+  _openRelaySocket(sessionId, params) {
     return new Promise((resolve, reject) => {
       let path = `${this.gkUrl}/relay/${sessionId}`;
-      if (this.relayParams) {
-        path = `${path}?${querystring.encode(this.relayParams)}`
+      if (Object.keys(params).length) {
+        path = `${path}?${querystring.encode(params)}`;
       }
       const socket = new this.WebSocket(this._webSocketUrl(path));
       socket.onopen = () => resolve(socket);
@@ -189,7 +195,7 @@ class Transcriber extends EventEmitter {
     }
   }
 
-  _handleSocketMessage({ data }) {
+  _handleSocketMessage({data}) {
     const parsed = JSON.parse(data);
     this._final = parsed.final || false;
     this.emit(TRANSCRIBER_DATA_RECEIVED, this, parsed);
@@ -224,19 +230,33 @@ class Transcriber extends EventEmitter {
 }
 
 // Internal States
-const UNINITIALIZED = Transcriber.UNINITIALIZED = Symbol('UNINITIALIZED');
-const INITIALIZING = Transcriber.INITIALIZING = Symbol('INITIALIZING');
-const ERROR = Transcriber.ERROR = Symbol('ERROR');
-const READY = Transcriber.READY = Symbol('READY');
-const INITIALIZING_RECORDING = Transcriber.INITIALIZING_RECORDING = Symbol('INITIALIZING_RECORDING');
-const RECORDING = Transcriber.RECORDING = Symbol('RECORDING');
-const FINALIZING_RECORDING = Transcriber.FINALIZING_RECORDING = Symbol('FINALIZING_RECORDING');
+const UNINITIALIZED = (Transcriber.UNINITIALIZED = Symbol('UNINITIALIZED'));
+const INITIALIZING = (Transcriber.INITIALIZING = Symbol('INITIALIZING'));
+const ERROR = (Transcriber.ERROR = Symbol('ERROR'));
+const READY = (Transcriber.READY = Symbol('READY'));
+const INITIALIZING_RECORDING = (Transcriber.INITIALIZING_RECORDING = Symbol(
+  'INITIALIZING_RECORDING',
+));
+const RECORDING = (Transcriber.RECORDING = Symbol('RECORDING'));
+const FINALIZING_RECORDING = (Transcriber.FINALIZING_RECORDING = Symbol(
+  'FINALIZING_RECORDING',
+));
 
 // External Events
-const TRANSCRIBER_READY = Transcriber.TRANSCRIBER_READY = Symbol('TRANSCRIBER_READY');
-const TRANSCRIBER_STARTED = Transcriber.TRANSCRIBER_STARTED = Symbol('TRANSCRIBER_STARTED');
-const TRANSCRIBER_CANCELED = Transcriber.TRANSCRIBER_CANCELED = Symbol('TRANSCRIBER_CANCELED');
-const TRANSCRIBER_STOPPED = Transcriber.TRANSCRIBER_STOPPED = Symbol('TRANSCRIBER_STOPPED');
-const TRANSCRIBER_DATA_RECEIVED = Transcriber.TRANSCRIBER_DATA_RECEIVED = Symbol('TRANSCRIBER_DATA_RECEIVED');
+const TRANSCRIBER_READY = (Transcriber.TRANSCRIBER_READY = Symbol(
+  'TRANSCRIBER_READY',
+));
+const TRANSCRIBER_STARTED = (Transcriber.TRANSCRIBER_STARTED = Symbol(
+  'TRANSCRIBER_STARTED',
+));
+const TRANSCRIBER_CANCELED = (Transcriber.TRANSCRIBER_CANCELED = Symbol(
+  'TRANSCRIBER_CANCELED',
+));
+const TRANSCRIBER_STOPPED = (Transcriber.TRANSCRIBER_STOPPED = Symbol(
+  'TRANSCRIBER_STOPPED',
+));
+const TRANSCRIBER_DATA_RECEIVED = (Transcriber.TRANSCRIBER_DATA_RECEIVED = Symbol(
+  'TRANSCRIBER_DATA_RECEIVED',
+));
 
 export default Transcriber;


### PR DESCRIPTION
A previous PR (#5) added the ability to add query string params to the audio and relay websocket connections, but you needed to specify them in the constructor. This PR allows you to specify them when calling the `start` method as well.