### PR TITLE
Adds optional sessionId argument to start method

### DIFF
--- a/src/Transcriber.js
+++ b/src/Transcriber.js
@@ -61,14 +61,14 @@ class Transcriber extends EventEmitter {
     return this._initPromise;
   }
 
-  start({audioParams = {}, relayParams = {}} = {}) {
+  start({audioParams = {}, relayParams = {}, sessionId = '' } = {}) {
     if (this.state !== READY) {
       throw new Error('Transcriber#start: not ready');
     }
 
     this.state = INITIALIZING_RECORDING;
 
-    const sessionId = uuid();
+    let sessionId = sessionId || uuid();
     const socketAudioParams = {...this.audioParams, ...audioParams};
     const socketRelayParams = {...this.relayParams, ...relayParams};
 


### PR DESCRIPTION
Adds an optional `sessionId` argument to `start` method. This will permit us to create a stub `transcript` in `dataServer` before allowing the `transcriber` to populate it with data.